### PR TITLE
Melange now needs absolute path to signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Build an apk for all architectures using melange:
 docker run --rm --privileged -v "${PWD}":/work \
     cgr.dev/chainguard/melange build melange.yaml \
     --arch amd64,aarch64,armv7 \
-    --signing-key melange.rsa
+    --signing-key /work/melange.rsa
 ```
 
 To debug the above:
@@ -88,7 +88,7 @@ docker run --rm --privileged -it -v "${PWD}":/work \
 # Build apks (use just --arch amd64 to isolate issue)
 melange build melange.yaml \
     --arch amd64,aarch64,armv7 \
-    --signing-key melange.rsa
+    --signing-key /work/melange.rsa
 
 # Install an apk
 apk add ./packages/x86_64/hello-server-*.apk --allow-untrusted --force-broken-world


### PR DESCRIPTION
This is because it just changed to the Go impl of apk, rather than shelling out.
Empirically, this isn't the case with Apko, yet.